### PR TITLE
fix: case wildcardcmp("foo*", "foo")

### DIFF
--- a/test.c
+++ b/test.c
@@ -6,6 +6,7 @@
 int
 main(void) {
   // positive
+	assert(1 == wildcardcmp("foo*", "foo"));
   assert(1 == wildcardcmp("foobar", "foobar"));
   assert(1 == wildcardcmp("*", "foobar"));
   assert(1 == wildcardcmp("foo*", "foobar"));

--- a/wildcardcmp.c
+++ b/wildcardcmp.c
@@ -14,6 +14,7 @@ wildcardcmp(const char *pattern, const char *string) {
   while (1) {
     if (!*string) {
       if (!*pattern) return 1;
+			if ('*' == *pattern) return 1;
       if (!*s) return 0;
       string = s++;
       pattern = w;


### PR DESCRIPTION
fix: case wildcardcmp("foo*", "foo")